### PR TITLE
Fixed ps returning all users' sessions, not $usr's

### DIFF
--- a/bin/fisbatch_base
+++ b/bin/fisbatch_base
@@ -175,7 +175,7 @@ log "Job is running on ${NODE}"
 
 for i in {1..1000}; do
     for i in $NODE; do
-       screenTest=$(ssh $i "ps -u $usr -ef | grep ${FISBATCH_CHECK_REGEX} | wc -l" 2>/dev/null)
+       screenTest=$(ssh $i "ps -u $usr -f | grep ${FISBATCH_CHECK_REGEX} | wc -l" 2>/dev/null)
        if [[ "$screenTest" != "0" ]]; then
           HNODE=$i
           break


### PR DESCRIPTION
-u $usr (only that user's processes) and -e (all processes) are mutually exclusive (and, based on testing this particular line, -e wins)